### PR TITLE
Influx-Client has been moved to influxdata

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/influxdb/influxdb/client/v2"
+	"github.com/influxdata/influxdb1-client/v2"
 	"io/ioutil"
 	"net/http"
 	"net/url"


### PR DESCRIPTION
The repository of the Influx Client has been moved to Influxdata.
This uses the repository linked on the Influx-Website: https://docs.influxdata.com/influxdb/v1.7/tools/api_client_libraries/